### PR TITLE
Make the plugin work with the current xsnippet API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: trusty
+language: python
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+
+install:
+  - pip install flake8 mock pytest
+
+script:
+  - flake8 plugin/ tests/
+  - PYTHONPATH="$(pwd)/plugin:$PYTHONPATH" pytest -s -v tests/
+
+notifications:
+  email: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 The XSnippet Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,15 @@
 vim-xsnippet
 ============
 
-**vim-xsnippet** is a simple Vim_ plugin which enables one to post code
-snippets to the xsnippet.org_ pastebin service directly from Vim.
+**vim-xsnippet** is a simple Vim_ plugin that enables one to post code
+snippets to xsnippet.org_ pastebin service directly from Vim.
 
 
 Requirements
 ------------
 
-* Python 2.x
-* Vim 7.x built with ``+python`` option
+* Python 2.7+
+* Vim 7.x+ built with ``+python``
 
 
 Installation
@@ -17,23 +17,27 @@ Installation
 
 Copy all files to your ``$VIMRUNTIME`` dir (usually ``~/.vim``).
 
-    **Note:** if you use pathogen, copy all files to some
-    dir in your bundles path.
+Alternatively, if you are using Vundle_ plug-in manager for Vim_, add the
+following line to your ``.vimrc``::
 
-Using
+    Bundle 'xsnippet/vim-xsnippet'
+
+
+Usage
 -----
 
 ``:call PostToXsnippet()``
-    posts the content of the current buffer to xsnippet.org_
-    and puts the snippet's url to the clipboard
+    posts the content of the current buffer to xsnippet.org_ and puts the
+    snippet url to the clipboard
 
 Info
 ----
 
-* Author:   Roman Podolyaka (roman.podolyaka@gmail.com)
-* License:  GNU GPL v3
+* Authors:  The XSnippet Team (dev@xsnippet.org)
+* License:  MIT
 * Homepage: https://github.com/xsnippet/vim-xsnippet
 
 
-.. _xsnippet.org: http://www.xsnippet.org/
+.. _xsnippet.org: https://xsnippet.org/
 .. _Vim: http://www.vim.org/
+.. _Vundle: https://github.com/VundleVim/Vundle.vim

--- a/plugin/xsnippet.vim
+++ b/plugin/xsnippet.vim
@@ -6,52 +6,46 @@ python import sys
 exe 'python sys.path.insert(0, "' . s:plugin_path . '")'
 
 python << EOF
-import os
-
-import getpass
-
 import vim
 import xsnippet
 
 FT_TO_LANGUAGE = {
-    "c": "c",
-    "cpp": "cpp",
+    "c": "c_cpp",
+    "cpp": "c_cpp",
     "cs": "csharp",
     "java": "java",
     "python": "python",
-    "sh": "bash",
-    "html": "html+php",
+    "sh": "sh",
+    "html": "html",
     "xml": "xml",
     "css": "css",
     "javascript": "javascript",
     "php": "php",
     "sql": "sql",
     "ruby": "ruby",
-    "apache": "apache",
-    "cmake": "cmake",
+    "apache": "apache_conf",
     "diff": "diff",
     "django": "django",
-    "dosbatch": "bat",
+    "dosbatch": "batchfile",
     "erlang": "erlang",
     "haskell": "haskell",
     "dosini": "ini",
-    "lisp": "cl",
+    "lisp": "lisp",
     "lua": "lua",
-    "objc": "objc",
+    "objc": "objectivec",
     "perl": "perl",
-    "tex": "tex",
+    "tex": "latex",
     "vhdl": "vhdl",
-    "verilog": "v",
-    "nasm": "nasm",
-    "asm": "gas",
+    "verilog": "verilog",
+    "asm": "assembly_x86",
     "yaml": "yaml",
-    "vim": "vim"
+    "dockerfile": "dockerfile"
 }
 
 url = xsnippet.post_snippet(
     content='\n'.join(vim.current.buffer[:]),
     title=vim.eval("expand('%:t')"),
-    language=FT_TO_LANGUAGE.get(vim.eval("&ft"), "text")
+    syntax=FT_TO_LANGUAGE.get(vim.eval("&ft"), "text")
 )
 
 vim.command("let @+ = '%s'" % url)

--- a/tests/test_xsnippet.py
+++ b/tests/test_xsnippet.py
@@ -1,0 +1,125 @@
+import json
+
+import mock
+import pytest
+
+try:
+    # python 3
+    import http.client as http
+except ImportError:
+    # python 2
+    import httplib as http
+
+import xsnippet
+
+
+@pytest.fixture
+def mocked_http():
+    with mock.patch.object(http, 'HTTPConnection') as mock_http:
+        with mock.patch.object(http, 'HTTPSConnection') as mock_https:
+            yield mock_http, mock_https
+
+
+TEST_SNIPPET = {
+    'id': 42,
+    'title': 'snippet #1',
+    'content': 'def foo(): pass',
+    'syntax': 'python',
+    'tags': [],
+    'created_at': '2018-06-17 22:00:00',
+    'updated_at': '2018-06-17 22:00:00',
+}
+
+
+def test_post_snippet(mocked_http):
+    _, mock_https = mocked_http
+
+    conn = mock_https.return_value
+    response = conn.getresponse.return_value
+
+    response.status = http.CREATED
+    response.read.return_value = json.dumps(TEST_SNIPPET)
+
+    rv = xsnippet.post_snippet(
+        title='snippet #1',
+        syntax='python',
+        content='def foo(): pass'
+    )
+    assert rv == 'https://xsnippet.org/42'
+
+    conn.request.assert_called_once_with(
+        'POST', '/v1/snippets',
+        body=json.dumps({
+            'content': 'def foo(): pass',
+            'title': 'snippet #1',
+            'syntax': 'python'
+        }),
+        headers={
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+        }
+    )
+    conn.close.assert_called_once_with()
+    mock_https.assert_called_once_with('api.xsnippet.org', 443, timeout=10)
+
+
+def test_post_snippet_overriden_settings(mocked_http, monkeypatch):
+    monkeypatch.setattr(xsnippet, 'API_URL', 'http://staging.xsnippet.org')
+    monkeypatch.setattr(xsnippet, 'WEB_URL', 'http://beta.xsnippet.org')
+    monkeypatch.setattr(xsnippet, 'TIMEOUT', 42)
+
+    mock_http, _ = mocked_http
+
+    conn = mock_http.return_value
+    response = conn.getresponse.return_value
+
+    response.status = http.CREATED
+    response.read.return_value = json.dumps(TEST_SNIPPET)
+
+    rv = xsnippet.post_snippet(
+        title='snippet #1',
+        syntax='python',
+        content='def foo(): pass'
+    )
+    assert rv == 'http://beta.xsnippet.org/42'
+
+    conn.request.assert_called_once_with(
+        'POST', '/v1/snippets',
+        body=json.dumps({
+            'content': 'def foo(): pass',
+            'title': 'snippet #1',
+            'syntax': 'python'
+        }),
+        headers={
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+        }
+    )
+    conn.close.assert_called_once_with()
+    mock_http.assert_called_once_with('staging.xsnippet.org', 80,
+                                      timeout=42)
+
+
+def test_post_snippet_error_response(mocked_http):
+    _, mock_https = mocked_http
+
+    conn = mock_https.return_value
+    response = conn.getresponse.return_value
+    response.status = 502  # simulate xsnippet api outage
+
+    with pytest.raises(ValueError, message='Failed to post a snippet'):
+        xsnippet.post_snippet(
+            title='snippet #1',
+            syntax='python',
+            content='def foo(): pass'
+        )
+    conn.close.assert_called_once_with()
+
+
+def test_post_snippet_empty_content(mocked_http):
+    with pytest.raises(ValueError, message='Can not post an empty snippet'):
+        xsnippet.post_snippet(
+            title='snippet #1',
+            syntax='python',
+            content=''
+        )


### PR DESCRIPTION
1. Update the code to work with the current API.

2. Change the license to MIT to be consistent with the rest of xsnippet/
projects.

3. Add basic unit tests.

In the follow up PRs, we need to:

1. Add a functional test (something like `vim -c ":call PostToXsnippet() | wq" some_file`)

2. Make use of vim background jobs (if we just run Python as a subprocess,
we won't need to care about which Python version this vim was linked against).